### PR TITLE
Minor codecov adjustments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 t
 docs/** linguist-documentation
 *.gtpl linguist-language=go
-# scripts/*.js linguist-vendored
+scripts/*.js linguist-vendored

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build, Test and Release
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
 on:
+  push:
+    branches: ["test/*"]
   pull_request:
 
 jobs:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   status:
-    patch: off
+    patch: false
     project:
       default:
         threshold: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        threshold: auto
+        target: auto

--- a/internal/utils/parse_urls_test.go
+++ b/internal/utils/parse_urls_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -218,11 +217,6 @@ https://more.com?foo=bar#baz
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			Wd = filepath.Join(root)
-
-			fmt.Println("--------------")
-			fmt.Println("wd", Wd)
-			fmt.Println(filepath.Join("tmp", "list.ini"))
-			fmt.Println("--------------")
 
 			got, diags := GetURLsFromArgs(test.Args)
 


### PR DESCRIPTION
Minor adjustments:
- disable the patch check.
- exclude scripts/*.js from linguist stats